### PR TITLE
fix choose theme dialog crash

### DIFF
--- a/core/src/main/res/values/themes.xml
+++ b/core/src/main/res/values/themes.xml
@@ -70,7 +70,7 @@
     </style>
 
     <style name="Base.ThemeOverlay.RugbyRanker.BottomSheetDialog" parent="ThemeOverlay.MaterialComponents.DayNight.BottomSheetDialog">
-        <item name="colorControlHighlight">@color/on_surface_32</item>
+        <item name="android:colorControlHighlight">@color/on_surface_32</item>
         <item name="android:windowLightStatusBar">false</item>
         <item name="bottomSheetStyle">@style/Widget.RugbyRanker.BottomSheet.Modal</item>
     </style>

--- a/core/src/main/res/values/themes.xml
+++ b/core/src/main/res/values/themes.xml
@@ -8,7 +8,7 @@
     <style name="Platform.Theme.RugbyRanker" parent="Platform.V24.Theme.RugbyRanker" />
 
     <style name="Base.Theme.RugbyRanker" parent="Platform.Theme.RugbyRanker">
-        <item name="colorControlHighlight">@color/on_surface_16</item>
+        <item name="android:colorControlHighlight">@color/on_surface_16</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="fontFamily">@font/rajdhani_semibold</item>
         <item name="android:fontFamily">@font/rajdhani_semibold</item>


### PR DESCRIPTION
This is a simple fix that prevents the app from crashing when a user tries to choose a theme.

Menu -> Info - > Choose Theme

Tested device: Samsung J5 pro

OS version: Pie